### PR TITLE
RSS Generator for SportsBlog

### DIFF
--- a/feedsn.pl
+++ b/feedsn.pl
@@ -56,7 +56,8 @@ while (my $article_tag = $stream->get_tag("article")) {
 	print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
 	$pubDate{$id_counter} = get_pubdate($stream);
 	print "  Found date " . $pubDate{$id_counter} . "\n" if $opt_debug;
-	# Get the first <p>. The article is in here
+	$text{$id_counter} = get_entry($stream);
+	print "  Found text " . $text{$id_counter} . "\n" if $opt_debug;
 
 	while (my $div_tag = $stream->get_tag("div")) {
 		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
@@ -153,12 +154,14 @@ sub get_subject() {
 
 sub get_entry() {
 	my $stream = shift;
-	my $entry = "No Entry";
-	while (my $div_tag = $stream->get_tag("div")) {
-
-		if ($div_tag->[1]{id} && $div_tag->[1]{id} eq "MBBody") {
-			$entry = $stream->get_phrase();
-			return($entry);
+	my $entry = "";
+	my $keep_going = 1;
+	while ($keep_going) {
+		my $t = $stream->get_tag("p", "div");
+		if ($t->[0] eq "div" and $t->[1]{class} eq "article-tags") {
+			$keep_going = 0;
+		} else {
+			$entry .= $stream->get_phrase();
 		}
 	}
 	return ($entry);

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -91,7 +91,7 @@ my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
   gmtime(time);
 
 my $feedname="rickonsports.rss";
-my $pubDate = POSIX::strftime( "%a, %d %b %Y %H:%M:00 GMT", $sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst);
+my $rssDate = POSIX::strftime( "%a, %d %b %Y %H:%M:00 GMT", $sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst);
 
 my $rss = new XML::RSS (version => '2.0');
 $rss->channel(title          => 'Rick Umali: Sports On My Mind',
@@ -99,8 +99,8 @@ $rss->channel(title          => 'Rick Umali: Sports On My Mind',
               language       => 'en',
               description    => 'Rick Umali\'s Take on Sports',
               copyright      => 'Copyright 2007, rickumali.com',
-              pubDate        => $pubDate,
-              lastBuildDate  => $pubDate,
+              pubDate        => $rssDate,
+              lastBuildDate  => $rssDate,
               docs           => 'http://feedvalidator.org/docs/rss2.html',
               managingEditor => 'rickumali@gmail.com',
               webMaster      => 'rickumali@gmail.com'

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -114,12 +114,10 @@ $rss->image(title       => 'Rick Umali: Sports On My Mind',
             description => 'Rick Umali'
            );
 
-foreach my $id (sort {$b cmp $a} keys %subject) {
-    my $display_id = $id;
-    $display_id =~ s/entry_//;
+for (my $id = 1; $id <= $article_count; $id++) {
     my $truncated_text = truncate_text($text{$id},160);
     $rss->add_item(title => $subject{$id},
-                   link  => "http://www.sportingnews.com/blog/rickumali/$display_id",
+                   link  => $link{$id},
                    pubDate  => $pubDate{$id},
                    permaLink  => $link{$id},
                    description => $truncated_text,

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -73,6 +73,13 @@ while (my $article_tag = $stream->get_tag("article")) {
   }
 }
 
+my $article_count = $id_counter;
+for (my $i = 2; $i <= $article_count; $i++) {
+  print "Walking: " . $link{$i} . "\n" if $opt_debug;
+  $agent->get($link{$id_counter});
+  my $stream = HTML::TokeParser->new(\$agent->{content});
+}
+
 exit 1;
 
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -74,6 +74,7 @@ while (my $article_tag = $stream->get_tag("article")) {
 }
 
 my $article_count = $id_counter;
+my $pattern_length = length("By rickumali MMM. DD, YYYY");
 for (my $i = 2; $i <= $article_count; $i++) {
   print "Walking: " . $link{$i} . "\n" if $opt_debug;
   $agent->get($link{$i});
@@ -81,6 +82,7 @@ for (my $i = 2; $i <= $article_count; $i++) {
   while (my $article_tag = $stream->get_tag("article")) {
     print "Found <article>\n" if $opt_debug;
     $text{$i} = get_entry($stream);
+    $text{$i} = substr $text{$i}, $pattern_length;
     print "Found text " . $text{$i} . "\n" if $opt_debug;
   }
 }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -63,9 +63,9 @@ while (my $article_tag = $stream->get_tag("article")) {
 		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
 			$id_counter += 1;
 			print "Found <div article-entry-content> " . $id_counter . "\n" if $opt_debug;
-			# Get the link from first following <h3><a>
-			# Walk link to get its contents
-			# Get the date from first following div
+			my $anchor_tag = $stream->get_tag("a");
+
+			print "  Found link: " . $anchor_tag->[1]{href} . "\n" if $opt_debug;
 		}
 	}
 }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -52,6 +52,8 @@ my $id_counter = 0;
 while (my $article_tag = $stream->get_tag("article")) {
 	$id_counter += 1;
 	print "Found <article> " . $id_counter . "\n" if $opt_debug;
+	$subject{$id_counter} = get_subject($stream);
+	print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
 	# Get the first <p>. The article is in here
 
 	while (my $div_tag = $stream->get_tag("div")) {
@@ -140,14 +142,9 @@ sub truncate_text() {
 sub get_subject() {
 	my $stream = shift;
 	my $subject = "No Subject";
-	while (my $div_tag = $stream->get_tag("div")) {
-
-		if ($div_tag->[1]{id} && $div_tag->[1]{id} eq "MBSubject") {
-			$stream->get_tag("a");
-			$stream->get_token();
-			$subject = $stream->get_trimmed_text();
-			return($subject);
-		}
+	while (my $h1_tag = $stream->get_tag("h1")) {
+		$subject = $stream->get_trimmed_text();
+		return($subject);
 	}
 	return ($subject);
 }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -82,6 +82,8 @@ for (my $i = 2; $i <= $article_count; $i++) {
   while (my $article_tag = $stream->get_tag("article")) {
     print "Found <article>\n" if $opt_debug;
     $text{$i} = get_entry($stream);
+    $pubDate{$i} = substr $text{$i}, 0, $pattern_length;
+    $pubDate{$i} = reformat_date($pubDate{$i});
     $text{$i} = substr $text{$i}, $pattern_length;
     print "Found text " . $text{$i} . "\n" if $opt_debug;
   }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -45,23 +45,29 @@ if ($opt_debug) {
 }
 
 my $agent = WWW::Mechanize->new();
-$agent->get("http://www.sportingnews.com/blog/rickumali");
+$agent->get("http://www.sportsblog.com/rickumali");
 
 my $stream = HTML::TokeParser->new(\$agent->{content});
 my %subject = ();
 my %text = ();
 my %pubDate = ();
 
-while (my $div_tag = $stream->get_tag("div")) {
+while (my $article_tag = $stream->get_tag("article")) {
+	print "Found <article>\n";
+	# Get the first <p>. The article is in here
 
-	if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "MBEntry") {
-		my $id = $div_tag->[1]{id};
-
-		$subject{$id} = get_subject($stream);
-		$pubDate{$id} = get_pubdate($stream);
-		$text{$id} = get_entry($stream);
+	while (my $div_tag = $stream->get_tag("div")) {
+		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
+			my $id = $div_tag->[1]{id};
+			print "Found <div article-entry-content>\n";
+			# Get the link from first following <h3><a>
+			# Walk link to get its contents
+			# Get the date from first following div
+		}
 	}
 }
+
+exit 1;
 
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
 	gmtime(time);

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -51,15 +51,17 @@ my $stream = HTML::TokeParser->new(\$agent->{content});
 my %subject = ();
 my %text = ();
 my %pubDate = ();
+my $id_counter = 0;
 
 while (my $article_tag = $stream->get_tag("article")) {
-	print "Found <article>\n";
+	$id_counter += 1;
+	print "Found <article> " . $id_counter . "\n";
 	# Get the first <p>. The article is in here
 
 	while (my $div_tag = $stream->get_tag("div")) {
 		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
-			my $id = $div_tag->[1]{id};
-			print "Found <div article-entry-content>\n";
+			$id_counter += 1;
+			print "Found <div article-entry-content> " . $id_counter . "\n";
 			# Get the link from first following <h3><a>
 			# Walk link to get its contents
 			# Get the date from first following div

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -76,7 +76,7 @@ while (my $article_tag = $stream->get_tag("article")) {
 my $article_count = $id_counter;
 for (my $i = 2; $i <= $article_count; $i++) {
   print "Walking: " . $link{$i} . "\n" if $opt_debug;
-  $agent->get($link{$id_counter});
+  $agent->get($link{$i});
   my $stream = HTML::TokeParser->new(\$agent->{content});
 }
 

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -173,7 +173,7 @@ sub get_pubdate() {
 		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "articles-author-name") {
 			$stream->get_tag("p");
 			$pub_date_raw = $stream->get_phrase();
-			$pub_date = $pub_date_raw;
+			$pub_date = reformat_date($pub_date_raw);
 			return($pub_date);
 		}
 	}
@@ -181,11 +181,18 @@ sub get_pubdate() {
 }
 
 sub reformat_date() {
+	# Read this raw date: By rickumali May. 13, 2017
 	my $pub_date_raw = shift;
-	# Read this format: # >Oct 06, 2007 07:47 PM
-	my ($raw_mon, $raw_day, $raw_year, $raw_time, $raw_merid) = split(' ', $pub_date_raw);
-	chop($raw_day);
-	my ($year, $month, $day) = Parse_Date($pub_date_raw);
+
+	# Remove the byline
+	$pub_date_raw = substr $pub_date_raw, length("By rickumali") + 1;
+	my ($raw_mon, $raw_day, $raw_year) = split(' ', $pub_date_raw);
+	chop($raw_mon); # Remove trailing period
+	chop($raw_day); # Remove trailing comma
+	my $raw_time = "7:00"; # Hardcoded
+	my $raw_merid = "PM"; # Hardcoded
+	my $new_raw = $raw_mon . " " . $raw_day . " " . $raw_year;
+	my ($year, $month, $day) = Parse_Date($new_raw);
 	my $dow = Day_of_Week($year, $month, $day);
 	my $today = Day_of_Week_to_Text($dow);
 	if ($raw_merid eq "PM") {

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -1,4 +1,4 @@
-#!/usr/pkg/bin/perl
+#!/usr/bin/env perl
 #
 # feedsn.pl
 #
@@ -36,8 +36,8 @@ GetOptions ('debug' => \$opt_debug,
             'version|v' => \$opt_version);
 
 if ($opt_version) {
-	print "feedsn.pl Version $opt_version\n";
-	exit 1;
+  print "feedsn.pl Version $opt_version\n";
+  exit 1;
 }
 
 my $agent = WWW::Mechanize->new();
@@ -51,32 +51,32 @@ my %pubDate = ();
 my $id_counter = 0;
 
 while (my $article_tag = $stream->get_tag("article")) {
-	$id_counter += 1;
-	$link{$id_counter} = "http://www.sportsblog.com/rickumali";
-	print "Found <article> " . $id_counter . "\n" if $opt_debug;
-	$subject{$id_counter} = get_subject($stream);
-	print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
-	$pubDate{$id_counter} = get_pubdate($stream);
-	print "  Found date " . $pubDate{$id_counter} . "\n" if $opt_debug;
-	$text{$id_counter} = get_entry($stream);
-	print "  Found text " . $text{$id_counter} . "\n" if $opt_debug;
+  $id_counter += 1;
+  $link{$id_counter} = "http://www.sportsblog.com/rickumali";
+  print "Found <article> " . $id_counter . "\n" if $opt_debug;
+  $subject{$id_counter} = get_subject($stream);
+  print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
+  $pubDate{$id_counter} = get_pubdate($stream);
+  print "  Found date " . $pubDate{$id_counter} . "\n" if $opt_debug;
+  $text{$id_counter} = get_entry($stream);
+  print "  Found text " . $text{$id_counter} . "\n" if $opt_debug;
 
-	while (my $div_tag = $stream->get_tag("div")) {
-		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
-			$id_counter += 1;
-			print "Found <div article-entry-content> " . $id_counter . "\n" if $opt_debug;
-			my $anchor_tag = $stream->get_tag("a");
+  while (my $div_tag = $stream->get_tag("div")) {
+    if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
+      $id_counter += 1;
+      print "Found <div article-entry-content> " . $id_counter . "\n" if $opt_debug;
+      my $anchor_tag = $stream->get_tag("a");
 
-			print "  Found link: " . $anchor_tag->[1]{href} . "\n" if $opt_debug;
-			$link{$id_counter} = $anchor_tag->[1]{href};
-		}
-	}
+      print "  Found link: " . $anchor_tag->[1]{href} . "\n" if $opt_debug;
+      $link{$id_counter} = $anchor_tag->[1]{href};
+    }
+  }
 }
 
 exit 1;
 
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
-	gmtime(time);
+  gmtime(time);
 
 my $feedname="rickonsports.rss";
 my $pubDate = POSIX::strftime( "%a, %d %b %Y %H:%M:00 GMT", $sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst);
@@ -121,96 +121,96 @@ $rss->save($feedname);
 exit 0;
 
 sub truncate_text() {
-	my $text = shift;
-	my $min_chars = shift; # Minimum number of characters for text
+  my $text = shift;
+  my $min_chars = shift; # Minimum number of characters for text
 
-	if (length($text) < $min_chars) {
-		return($text);
-	}
+  if (length($text) < $min_chars) {
+    return($text);
+  }
 
-	my $pos = 0;
-	while ($pos < $min_chars) {
-		$pos = index($text, " ", $pos+1);
-		if ($pos == -1) {
-			# This bailout code was added following an
-			# outage I caused on rickumali.com. There are
-			# some instances of this while() loop going into
-			# an infinite loop. This bailout code catches
-			# that. (10-19-2008)
-			last;
-		}
-	}
+  my $pos = 0;
+  while ($pos < $min_chars) {
+    $pos = index($text, " ", $pos+1);
+    if ($pos == -1) {
+      # This bailout code was added following an
+      # outage I caused on rickumali.com. There are
+      # some instances of this while() loop going into
+      # an infinite loop. This bailout code catches
+      # that. (10-19-2008)
+      last;
+    }
+  }
 
-	return(substr($text,0,$pos) . " ...");
+  return(substr($text,0,$pos) . " ...");
 
 }
 
 sub get_subject() {
-	my $stream = shift;
-	my $subject = "No Subject";
-	while (my $h1_tag = $stream->get_tag("h1")) {
-		$subject = $stream->get_trimmed_text();
-		return($subject);
-	}
-	return ($subject);
+  my $stream = shift;
+  my $subject = "No Subject";
+  while (my $h1_tag = $stream->get_tag("h1")) {
+    $subject = $stream->get_trimmed_text();
+    return($subject);
+  }
+  return ($subject);
 }
 
 sub get_entry() {
-	my $stream = shift;
-	my $entry = "";
-	my $keep_going = 1;
-	while ($keep_going) {
-		my $t = $stream->get_tag("p", "div");
-		if ($t->[0] eq "div" and $t->[1]{class} eq "article-tags") {
-			$keep_going = 0;
-		} else {
-			$entry .= $stream->get_phrase();
-		}
-	}
-	return ($entry);
+  my $stream = shift;
+  my $entry = "";
+  my $keep_going = 1;
+  while ($keep_going) {
+    my $t = $stream->get_tag("p", "div");
+    if ($t->[0] eq "div" and $t->[1]{class} eq "article-tags") {
+      $keep_going = 0;
+    } else {
+      $entry .= $stream->get_phrase();
+    }
+  }
+  return ($entry);
 }
 
 sub get_pubdate() {
-	my $stream = shift;
-	my $pub_date_raw = "No Entry";
-	my $pub_date = "No Entry";
-	while (my $div_tag = $stream->get_tag("div")) {
+  my $stream = shift;
+  my $pub_date_raw = "No Entry";
+  my $pub_date = "No Entry";
+  while (my $div_tag = $stream->get_tag("div")) {
 
-		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "articles-author-name") {
-			$stream->get_tag("p");
-			$pub_date_raw = $stream->get_phrase();
-			$pub_date = reformat_date($pub_date_raw);
-			return($pub_date);
-		}
-	}
-	return ($pub_date_raw);
+    if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "articles-author-name") {
+      $stream->get_tag("p");
+      $pub_date_raw = $stream->get_phrase();
+      $pub_date = reformat_date($pub_date_raw);
+      return($pub_date);
+    }
+  }
+  return ($pub_date_raw);
 }
 
 sub reformat_date() {
-	# Read this raw date: By rickumali May. 13, 2017
-	my $pub_date_raw = shift;
+  # Read this raw date: By rickumali May. 13, 2017
+  my $pub_date_raw = shift;
 
-	# Remove the byline
-	$pub_date_raw = substr $pub_date_raw, length("By rickumali") + 1;
-	my ($raw_mon, $raw_day, $raw_year) = split(' ', $pub_date_raw);
-	chop($raw_mon); # Remove trailing period
-	chop($raw_day); # Remove trailing comma
-	my $raw_time = "7:00"; # Hardcoded
-	my $raw_merid = "PM"; # Hardcoded
-	my $new_raw = $raw_mon . " " . $raw_day . " " . $raw_year;
-	my ($year, $month, $day) = Parse_Date($new_raw);
-	my $dow = Day_of_Week($year, $month, $day);
-	my $today = Day_of_Week_to_Text($dow);
-	if ($raw_merid eq "PM") {
-		my ($hour,$min) = split(":", $raw_time);
-		$hour+=12;
-		if ($hour == 24) {
-			$hour = 12;
-		}
-		$raw_time=sprintf("%02s:%02s",$hour,$min);
-	}
-	
-	# Generate this format: Sat, 07 Sep 2002 9:42:31 GMT
-	return(sprintf("%.3s, %s %s %s %s:00 EDT", 
-		$today,$raw_day,$raw_mon,$year,$raw_time));
+  # Remove the byline
+  $pub_date_raw = substr $pub_date_raw, length("By rickumali") + 1;
+  my ($raw_mon, $raw_day, $raw_year) = split(' ', $pub_date_raw);
+  chop($raw_mon); # Remove trailing period
+  chop($raw_day); # Remove trailing comma
+  my $raw_time = "7:00"; # Hardcoded
+  my $raw_merid = "PM"; # Hardcoded
+  my $new_raw = $raw_mon . " " . $raw_day . " " . $raw_year;
+  my ($year, $month, $day) = Parse_Date($new_raw);
+  my $dow = Day_of_Week($year, $month, $day);
+  my $today = Day_of_Week_to_Text($dow);
+  if ($raw_merid eq "PM") {
+    my ($hour,$min) = split(":", $raw_time);
+    $hour+=12;
+    if ($hour == 24) {
+      $hour = 12;
+    }
+    $raw_time=sprintf("%02s:%02s",$hour,$min);
+  }
+
+  # Generate this format: Sat, 07 Sep 2002 9:42:31 GMT
+  return(sprintf("%.3s, %s %s %s %s:00 EDT", 
+    $today,$raw_day,$raw_mon,$year,$raw_time));
 }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -44,6 +44,7 @@ my $agent = WWW::Mechanize->new();
 $agent->get("http://www.sportsblog.com/rickumali");
 
 my $stream = HTML::TokeParser->new(\$agent->{content});
+my %link = ();
 my %subject = ();
 my %text = ();
 my %pubDate = ();
@@ -51,6 +52,7 @@ my $id_counter = 0;
 
 while (my $article_tag = $stream->get_tag("article")) {
 	$id_counter += 1;
+	$link{$id_counter} = "http://www.sportsblog.com/rickumali";
 	print "Found <article> " . $id_counter . "\n" if $opt_debug;
 	$subject{$id_counter} = get_subject($stream);
 	print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
@@ -66,6 +68,7 @@ while (my $article_tag = $stream->get_tag("article")) {
 			my $anchor_tag = $stream->get_tag("a");
 
 			print "  Found link: " . $anchor_tag->[1]{href} . "\n" if $opt_debug;
+			$link{$id_counter} = $anchor_tag->[1]{href};
 		}
 	}
 }

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -81,6 +81,8 @@ for (my $i = 2; $i <= $article_count; $i++) {
   my $stream = HTML::TokeParser->new(\$agent->{content});
   while (my $article_tag = $stream->get_tag("article")) {
     print "Found <article>\n" if $opt_debug;
+    $subject{$i} = get_subject($stream);
+    print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
     $text{$i} = get_entry($stream);
     $pubDate{$i} = substr $text{$i}, 0, $pattern_length;
     $pubDate{$i} = reformat_date($pubDate{$i});

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -78,6 +78,11 @@ for (my $i = 2; $i <= $article_count; $i++) {
   print "Walking: " . $link{$i} . "\n" if $opt_debug;
   $agent->get($link{$i});
   my $stream = HTML::TokeParser->new(\$agent->{content});
+  while (my $article_tag = $stream->get_tag("article")) {
+    print "Found <article>\n" if $opt_debug;
+    $text{$i} = get_entry($stream);
+    print "Found text " . $text{$i} . "\n" if $opt_debug;
+  }
 }
 
 exit 1;

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -40,10 +40,6 @@ if ($opt_version) {
 	exit 1;
 }
 
-if ($opt_debug) {
-	exit 1;
-}
-
 my $agent = WWW::Mechanize->new();
 $agent->get("http://www.sportsblog.com/rickumali");
 
@@ -55,13 +51,13 @@ my $id_counter = 0;
 
 while (my $article_tag = $stream->get_tag("article")) {
 	$id_counter += 1;
-	print "Found <article> " . $id_counter . "\n";
+	print "Found <article> " . $id_counter . "\n" if $opt_debug;
 	# Get the first <p>. The article is in here
 
 	while (my $div_tag = $stream->get_tag("div")) {
 		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "article-entry-content") {
 			$id_counter += 1;
-			print "Found <div article-entry-content> " . $id_counter . "\n";
+			print "Found <div article-entry-content> " . $id_counter . "\n" if $opt_debug;
 			# Get the link from first following <h3><a>
 			# Walk link to get its contents
 			# Get the date from first following div

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -54,6 +54,8 @@ while (my $article_tag = $stream->get_tag("article")) {
 	print "Found <article> " . $id_counter . "\n" if $opt_debug;
 	$subject{$id_counter} = get_subject($stream);
 	print "  Found subject: " . $subject{$id_counter} . "\n" if $opt_debug;
+	$pubDate{$id_counter} = get_pubdate($stream);
+	print "  Found date " . $pubDate{$id_counter} . "\n" if $opt_debug;
 	# Get the first <p>. The article is in here
 
 	while (my $div_tag = $stream->get_tag("div")) {
@@ -168,10 +170,10 @@ sub get_pubdate() {
 	my $pub_date = "No Entry";
 	while (my $div_tag = $stream->get_tag("div")) {
 
-		if ($div_tag->[1]{id} && $div_tag->[1]{id} eq "MBSubLine") {
-			$stream->get_tag("em");
-			$pub_date_raw = $stream->get_trimmed_text();
-			$pub_date = reformat_date($pub_date_raw);
+		if ($div_tag->[1]{class} && $div_tag->[1]{class} eq "articles-author-name") {
+			$stream->get_tag("p");
+			$pub_date_raw = $stream->get_phrase();
+			$pub_date = $pub_date_raw;
 			return($pub_date);
 		}
 	}

--- a/feedsn.pl
+++ b/feedsn.pl
@@ -87,8 +87,6 @@ for (my $i = 2; $i <= $article_count; $i++) {
   }
 }
 
-exit 1;
-
 my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
   gmtime(time);
 
@@ -96,8 +94,8 @@ my $feedname="rickonsports.rss";
 my $pubDate = POSIX::strftime( "%a, %d %b %Y %H:%M:00 GMT", $sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst);
 
 my $rss = new XML::RSS (version => '2.0');
-$rss->channel(title          => 'Rick on Sports',
-              link           => 'http://www.sportingnews.com/blog/rickumali',
+$rss->channel(title          => 'Rick Umali: Sports On My Mind',
+              link           => 'https://www.sportsblog.com/rickumali/',
               language       => 'en',
               description    => 'Rick Umali\'s Take on Sports',
               copyright      => 'Copyright 2007, rickumali.com',
@@ -108,9 +106,9 @@ $rss->channel(title          => 'Rick on Sports',
               webMaster      => 'rickumali@gmail.com'
              );
 
-$rss->image(title       => 'Rick on Sports',
+$rss->image(title       => 'Rick Umali: Sports On My Mind',
             url         => 'http://www.rodrigoumali.com/rick05.jpg',
-            link           => 'http://www.sportingnews.com/blog/rickumali',
+            link        => 'https://www.sportsblog.com/rickumali/',
             width       => 144,
             height      => 130,
             description => 'Rick Umali'
@@ -123,8 +121,7 @@ foreach my $id (sort {$b cmp $a} keys %subject) {
     $rss->add_item(title => $subject{$id},
                    link  => "http://www.sportingnews.com/blog/rickumali/$display_id",
                    pubDate  => $pubDate{$id},
-                   permaLink  =>
-"http://www.sportingnews.com/blog/rickumali/$display_id",
+                   permaLink  => $link{$id},
                    description => $truncated_text,
                   );
 }


### PR DESCRIPTION
The vanity website relies on RSS feeds. When I switched my blogging platform to sportsblog.com, they originally provided an RSS feed, but a few months ago they switched their layout, and they stopped generating the RSS feed. I resuscitated this old Perl program and modified it to read sportsblog.com's funky HTML. Now I have an RSS feed again.